### PR TITLE
Add Excel export for Telegram bot

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "axios": "^1.10.0",
     "dotenv": "^17.0.0",
-    "node-telegram-bot-api": "^0.66.0"
+    "node-telegram-bot-api": "^0.66.0",
+    "exceljs": "^4.3.0"
   }
 }

--- a/src/bot.js
+++ b/src/bot.js
@@ -4,6 +4,7 @@ dotenv.config();
 import TelegramBot from 'node-telegram-bot-api';
 import axios from 'axios';
 import { processImageWithGPT4o } from './services/openaiService.js';
+import { generateExcelFromData } from './services/excelService.js';
 
 const bot = new TelegramBot(process.env.TELEGRAM_BOT_TOKEN, { polling: true });
 
@@ -22,7 +23,21 @@ bot.on('message', async (msg) => {
       const base64 = Buffer.from(response.data).toString('base64');
       const result = await processImageWithGPT4o(base64);
 
-      bot.sendMessage(chatId, `📋 Datos extraídos:\n\n${result}`);
+      if (typeof result === 'object') {
+        const buffer = await generateExcelFromData(result);
+        await bot.sendDocument(
+          chatId,
+          buffer,
+          {},
+          {
+            filename: 'datos.xlsx',
+            contentType:
+              'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          }
+        );
+      } else {
+        bot.sendMessage(chatId, `📋 Datos extraídos:\n\n${result}`);
+      }
     } catch (error) {
       console.error(error);
       bot.sendMessage(chatId, '❌ Error al procesar la imagen.');

--- a/src/services/excelService.js
+++ b/src/services/excelService.js
@@ -1,0 +1,26 @@
+import ExcelJS from 'exceljs';
+
+export async function generateExcelFromData(data) {
+  const workbook = new ExcelJS.Workbook();
+  const worksheet = workbook.addWorksheet('Datos');
+
+  worksheet.columns = [
+    { header: 'Producto/Preparación/Material Auxiliar/Materia Prima', key: 'producto', width: 30 },
+    { header: 'Lote MMP/Lote Interno/Número de Carro', key: 'lote', width: 30 },
+    { header: 'Cantidad (kg)', key: 'cantidad', width: 15 },
+    { header: 'Descripción del motivo de merma', key: 'motivo', width: 30 },
+    { header: 'Responsable', key: 'responsable', width: 20 },
+    { header: 'Turno', key: 'turno', width: 10 }
+  ];
+
+  worksheet.addRow({
+    producto: data.producto || '',
+    lote: data.lote || '',
+    cantidad: data.cantidad || '',
+    motivo: data.motivo || '',
+    responsable: data.responsable || '',
+    turno: data.turno || ''
+  });
+
+  return workbook.xlsx.writeBuffer();
+}

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -32,5 +32,10 @@ export async function processImageWithGPT4o(base64Image) {
     }
   );
 
-  return response.data.choices[0].message.content;
+  const result = response.data.choices[0].message.content;
+  try {
+    return JSON.parse(result);
+  } catch (err) {
+    return result;
+  }
 }


### PR DESCRIPTION
## Summary
- add exceljs dependency
- parse JSON response in openAI service
- create service to build XLSX buffer from data
- update bot to send XLSX instead of JSON text when possible

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686133c6c9d8832ba362770184db50e4