### PR TITLE
Improve OCR context and excel generation

### DIFF
--- a/src/services/excelService.js
+++ b/src/services/excelService.js
@@ -13,14 +13,17 @@ export async function generateExcelFromData(data) {
     { header: 'Turno', key: 'turno', width: 10 }
   ];
 
-  worksheet.addRow({
-    producto: data.producto || '',
-    lote: data.lote || '',
-    cantidad: data.cantidad || '',
-    motivo: data.motivo || '',
-    responsable: data.responsable || '',
-    turno: data.turno || ''
-  });
+  const rows = Array.isArray(data) ? data : [data];
+  rows.forEach((row) =>
+    worksheet.addRow({
+      producto: row.producto || '',
+      lote: row.lote || '',
+      cantidad: row.cantidad || '',
+      motivo: row.motivo || '',
+      responsable: row.responsable || '',
+      turno: row.turno || '',
+    })
+  );
 
   return workbook.xlsx.writeBuffer();
 }

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -17,12 +17,15 @@ export async function processImageWithGPT4o(base64Image) {
             },
             {
               type: 'text',
-              text: 'Extrae todos los datos relevantes de esta tabla en formato JSON estructurado. Claves esperadas: producto, lote, cantidad, motivo, responsable, turno.',
+              text:
+                'Analiza la tabla de la imagen y extrae su contenido. Este tipo de tablas suele incluir columnas como "Producto/Preparación/Material Auxiliar/Materia Prima", "Lote MMP/Lote Interno/Número de Carro", "Cantidad (kg)", "Descripción del motivo de merma", "Responsable" y "Turno". Devuelve únicamente un arreglo JSON de objetos utilizando las claves: producto, lote, cantidad, motivo, responsable y turno. No incluyas texto adicional.',
             },
           ],
         },
       ],
       max_tokens: 1000,
+      temperature: 0,
+      response_format: { type: 'json_object' },
     },
     {
       headers: {


### PR DESCRIPTION
## Summary
- enhance the OpenAI prompt to include table context and enforce JSON replies
- generate Excel rows from arrays or single objects

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68613535342c832bbbcca065f1d506ee