### PR TITLE
Add Jest tests and config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+export default {
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.js'],
+  transform: {}
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "src/bot.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js"
   },
   "keywords": [],
   "author": "",
@@ -15,5 +15,9 @@
     "dotenv": "^17.0.0",
     "exceljs": "^4.4.0",
     "node-telegram-bot-api": "^0.66.0"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "jest": "^29.7.0"
   }
 }

--- a/tests/excelService.test.js
+++ b/tests/excelService.test.js
@@ -1,0 +1,62 @@
+import { jest } from '@jest/globals';
+
+const ExcelJS = {};
+class Worksheet {
+  constructor(name) {
+    this.name = name;
+    this.columns = [];
+    this.rows = [];
+  }
+  addRow(row) {
+    this.rows.push(row);
+  }
+}
+class Workbook {
+  constructor() {
+    ExcelJS.__lastWorkbook = this;
+    this.worksheets = [];
+    this.xlsx = { writeBuffer: jest.fn().mockResolvedValue(Buffer.from('x')) };
+  }
+  addWorksheet(name) {
+    const ws = new Worksheet(name);
+    this.worksheets.push(ws);
+    return ws;
+  }
+}
+ExcelJS.Workbook = Workbook;
+ExcelJS.__lastWorkbook = null;
+
+jest.unstable_mockModule('exceljs', () => ({ default: ExcelJS }));
+
+let generateExcelFromData;
+let exceljs;
+
+beforeAll(async () => {
+  exceljs = await import('exceljs');
+  ({ generateExcelFromData } = await import('../src/services/excelService.js'));
+});
+
+test('generateExcelFromData sets headers and rows', async () => {
+  const sample = {
+    producto: 'Prod',
+    lote: 'L1',
+    cantidad: '5',
+    motivo: 'M',
+    responsable: 'R',
+    turno: 'T',
+  };
+  const buf = await generateExcelFromData(sample);
+  expect(buf).toBeInstanceOf(Buffer);
+  const workbook = exceljs.default.__lastWorkbook;
+  const ws = workbook.worksheets[0];
+  expect(ws.columns.map(c => c.header)).toEqual([
+    'Producto/Preparación/Material Auxiliar/Materia Prima',
+    'Lote MMP/Lote Interno/Número de Carro',
+    'Cantidad (kg)',
+    'Descripción del motivo de merma',
+    'Responsable',
+    'Turno'
+  ]);
+  expect(ws.rows[0]).toEqual(sample);
+  expect(workbook.xlsx.writeBuffer).toHaveBeenCalled();
+});

--- a/tests/openaiService.test.js
+++ b/tests/openaiService.test.js
@@ -1,0 +1,31 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('axios', () => ({
+  default: { post: jest.fn() }
+}));
+
+let processImageWithGPT4o;
+let axios;
+
+beforeAll(async () => {
+  ({ default: axios } = await import('axios'));
+  ({ processImageWithGPT4o } = await import('../src/services/openaiService.js'));
+});
+
+describe('processImageWithGPT4o', () => {
+  beforeEach(() => {
+    axios.post.mockReset();
+  });
+
+  test('parses JSON response', async () => {
+    axios.post.mockResolvedValue({ data: { choices: [{ message: { content: '{"a":1}' } }] } });
+    const result = await processImageWithGPT4o('img');
+    expect(result).toEqual({ a: 1 });
+  });
+
+  test('returns raw string when JSON parse fails', async () => {
+    axios.post.mockResolvedValue({ data: { choices: [{ message: { content: 'not json' } }] } });
+    const result = await processImageWithGPT4o('img');
+    expect(result).toBe('not json');
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest with ESM config and test script
- test `processImageWithGPT4o` parsing logic
- mock ExcelJS to test `generateExcelFromData`

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68614149dff0832b961b78913c138fee