### PR TITLE
Add npm start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Ejecuta el bot con Node.js:
 node src/bot.js
 ```
 
+O con el script de npm:
+
+```bash
+npm start
+```
+
 Una vez en funcionamiento, envíale al bot una foto que contenga una tabla. El bot enviará un mensaje de confirmación mientras procesa la imagen.
 
 - Si los datos se reconocen como una colección de objetos, el bot generará un archivo `datos.xlsx` con la información estructurada.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "src/bot.js",
   "type": "module",
   "scripts": {
-    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js"
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
+    "start": "node src/bot.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add start script to package.json
- document running with npm start in README

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686143107938832bbe4518ef74f41c83