### PR TITLE
Improve error handling and OCR instructions

### DIFF
--- a/src/services/excelService.js
+++ b/src/services/excelService.js
@@ -14,16 +14,18 @@ export async function generateExcelFromData(data) {
   ];
 
   const rows = Array.isArray(data) ? data : [data];
-  rows.forEach((row) =>
-    worksheet.addRow({
-      producto: row.producto || '',
-      lote: row.lote || '',
-      cantidad: row.cantidad || '',
-      motivo: row.motivo || '',
-      responsable: row.responsable || '',
-      turno: row.turno || '',
-    })
-  );
+  rows
+    .filter((row) => row && typeof row === 'object')
+    .forEach((row) =>
+      worksheet.addRow({
+        producto: row.producto || '',
+        lote: row.lote || '',
+        cantidad: row.cantidad || '',
+        motivo: row.motivo || '',
+        responsable: row.responsable || '',
+        turno: row.turno || '',
+      })
+    );
 
   return workbook.xlsx.writeBuffer();
 }

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -17,8 +17,8 @@ export async function processImageWithGPT4o(base64Image) {
             },
             {
               type: 'text',
-              text:
-                'Analiza la tabla de la imagen y extrae su contenido. Este tipo de tablas suele incluir columnas como "Producto/Preparación/Material Auxiliar/Materia Prima", "Lote MMP/Lote Interno/Número de Carro", "Cantidad (kg)", "Descripción del motivo de merma", "Responsable" y "Turno". Devuelve únicamente un arreglo JSON de objetos utilizando las claves: producto, lote, cantidad, motivo, responsable y turno. No incluyas texto adicional.',
+          text:
+            'Analiza la tabla de la imagen y extrae su contenido. Este tipo de tablas suele incluir columnas como "Producto/Preparación/Material Auxiliar/Materia Prima", "Lote MMP/Lote Interno/Número de Carro", "Cantidad (kg)", "Descripción del motivo de merma", "Responsable" y "Turno".\n\nPresta especial atención a la columna "Descripción del motivo de merma"; dedica tiempo extra a revisarla y detallar este campo con la mayor precisión posible, ya que suele presentar el mayor margen de error. Devuelve únicamente un arreglo JSON de objetos utilizando las claves: producto, lote, cantidad, motivo, responsable y turno. No incluyas texto adicional.',
             },
           ],
         },

--- a/tests/excelService.test.js
+++ b/tests/excelService.test.js
@@ -60,3 +60,11 @@ test('generateExcelFromData sets headers and rows', async () => {
   expect(ws.rows[0]).toEqual(sample);
   expect(workbook.xlsx.writeBuffer).toHaveBeenCalled();
 });
+
+test('generateExcelFromData skips null entries', async () => {
+  const sample = { producto: 'P' };
+  await generateExcelFromData([null, sample]);
+  const workbook = exceljs.default.__lastWorkbook;
+  const ws = workbook.worksheets[0];
+  expect(ws.rows).toEqual([sample]);
+});


### PR DESCRIPTION
## Summary
- skip null entries when creating Excel rows
- emphasize careful review of "Descripción del motivo de merma" in the GPT prompt
- test that generateExcelFromData ignores null data

## Testing
- `npm test` *(fails: Cannot find module 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_686293cc2b9c832b864badc6e2a78357