### PR TITLE
Add Tesseract service

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Una vez en funcionamiento, envíale al bot una foto que contenga una tabla. El b
 - `src/bot.js`: punto de entrada del bot de Telegram.
 - `src/services/openaiService.js`: se comunica con la API de OpenAI para procesar la imagen y extraer la información de la tabla.
 - `src/services/excelService.js`: genera un archivo Excel a partir de los datos obtenidos.
+- `src/services/tesseractService.js`: extrae texto de imágenes utilizando Tesseract.
 
 ## Variables de entorno
 
@@ -58,4 +59,29 @@ Una vez en funcionamiento, envíale al bot una foto que contenga una tabla. El b
 ## Licencia
 
 ISC
+
+## Usar Tesseract como motor OCR
+
+Si prefieres que el reconocimiento de texto se realice de manera local,
+puedes utilizar [Tesseract.js](https://github.com/naptha/tesseract.js).
+Instálalo con:
+
+```bash
+npm install tesseract.js
+```
+
+Luego emplea el servicio `tesseractService.js` para extraer el texto:
+
+```javascript
+import { processImageWithTesseract } from './src/services/tesseractService.js';
+
+const texto = await processImageWithTesseract(buffer, 'spa');
+```
+
+Flujo sugerido:
+
+1. Recibir la imagen desde Telegram u otra fuente.
+2. Pasarla a `processImageWithTesseract` para obtener el texto plano.
+3. Procesar ese texto según tus necesidades, por ejemplo generando el Excel
+   con `generateExcelFromData`.
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "axios": "^1.10.0",
     "dotenv": "^17.0.0",
     "exceljs": "^4.4.0",
-    "node-telegram-bot-api": "^0.66.0"
+    "node-telegram-bot-api": "^0.66.0",
+    "tesseract.js": "^4.0.2"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/src/services/tesseractService.js
+++ b/src/services/tesseractService.js
@@ -1,0 +1,13 @@
+import { createWorker } from 'tesseract.js';
+
+export async function processImageWithTesseract(imageBuffer, lang = 'eng') {
+  const worker = await createWorker();
+  try {
+    await worker.loadLanguage(lang);
+    await worker.initialize(lang);
+    const { data: { text } } = await worker.recognize(imageBuffer);
+    return text;
+  } finally {
+    await worker.terminate();
+  }
+}

--- a/tests/tesseractService.test.js
+++ b/tests/tesseractService.test.js
@@ -1,0 +1,38 @@
+import { jest } from '@jest/globals';
+
+const worker = {
+  loadLanguage: jest.fn(),
+  initialize: jest.fn(),
+  recognize: jest.fn().mockResolvedValue({ data: { text: 'txt' } }),
+  terminate: jest.fn(),
+};
+
+jest.unstable_mockModule('tesseract.js', () => ({
+  createWorker: jest.fn(() => worker),
+}));
+
+let processImageWithTesseract;
+
+beforeAll(async () => {
+  ({ processImageWithTesseract } = await import('../src/services/tesseractService.js'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('processImageWithTesseract returns recognized text', async () => {
+  const text = await processImageWithTesseract('img');
+  expect(text).toBe('txt');
+  expect(worker.loadLanguage).toHaveBeenCalledWith('eng');
+  expect(worker.initialize).toHaveBeenCalledWith('eng');
+  expect(worker.recognize).toHaveBeenCalledWith('img');
+  expect(worker.terminate).toHaveBeenCalled();
+});
+
+
+test('processImageWithTesseract supports custom language', async () => {
+  await processImageWithTesseract('img', 'spa');
+  expect(worker.loadLanguage).toHaveBeenCalledWith('spa');
+  expect(worker.initialize).toHaveBeenCalledWith('spa');
+});


### PR DESCRIPTION
## Summary
- add a service that uses Tesseract to do OCR
- add tests for the new service
- document how to use Tesseract in the README
- list `tesseract.js` as a dependency

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68629aa93c10832bbd6d9267b0963d70