### PR TITLE
Integrate Tesseract OCR with OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Una vez en funcionamiento, envíale al bot una foto que contenga una tabla. El b
 ## Estructura del proyecto
 
 - `src/bot.js`: punto de entrada del bot de Telegram.
-- `src/services/openaiService.js`: se comunica con la API de OpenAI para procesar la imagen y extraer la información de la tabla.
+- `src/services/openaiService.js`: se comunica con la API de OpenAI para procesar la imagen o el texto extraído y obtener la información estructurada.
 - `src/services/excelService.js`: genera un archivo Excel a partir de los datos obtenidos.
 - `src/services/tesseractService.js`: extrae texto de imágenes utilizando Tesseract.
 
@@ -74,14 +74,16 @@ Luego emplea el servicio `tesseractService.js` para extraer el texto:
 
 ```javascript
 import { processImageWithTesseract } from './src/services/tesseractService.js';
+import { analyzeTableTextWithGPT4o } from './src/services/openaiService.js';
 
 const texto = await processImageWithTesseract(buffer, 'spa');
+const datos = await analyzeTableTextWithGPT4o(texto);
 ```
 
 Flujo sugerido:
 
 1. Recibir la imagen desde Telegram u otra fuente.
 2. Pasarla a `processImageWithTesseract` para obtener el texto plano.
-3. Procesar ese texto según tus necesidades, por ejemplo generando el Excel
-   con `generateExcelFromData`.
+3. Enviar el texto a `analyzeTableTextWithGPT4o` para corregirlo y estructurarlo.
+4. Generar el Excel con `generateExcelFromData` usando los datos devueltos.
 

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -43,3 +43,36 @@ export async function processImageWithGPT4o(base64Image) {
     return result;
   }
 }
+
+export async function analyzeTableTextWithGPT4o(ocrText) {
+  const response = await axios.post(
+    'https://api.openai.com/v1/chat/completions',
+    {
+      model: 'gpt-4o',
+      messages: [
+        {
+          role: 'user',
+          content:
+            'Corrige y estructura el siguiente texto reconocido por OCR. Devuelve únicamente un arreglo JSON de objetos con las claves: producto, lote, cantidad, motivo, responsable y turno.\n\n' +
+            ocrText,
+        },
+      ],
+      max_tokens: 1000,
+      temperature: 0,
+      response_format: { type: 'json_object' },
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+
+  const result = response.data.choices[0].message.content;
+  try {
+    return JSON.parse(result);
+  } catch (err) {
+    return result;
+  }
+}

--- a/tests/openaiService.test.js
+++ b/tests/openaiService.test.js
@@ -5,11 +5,12 @@ jest.unstable_mockModule('axios', () => ({
 }));
 
 let processImageWithGPT4o;
+let analyzeTableTextWithGPT4o;
 let axios;
 
 beforeAll(async () => {
   ({ default: axios } = await import('axios'));
-  ({ processImageWithGPT4o } = await import('../src/services/openaiService.js'));
+  ({ processImageWithGPT4o, analyzeTableTextWithGPT4o } = await import('../src/services/openaiService.js'));
 });
 
 describe('processImageWithGPT4o', () => {
@@ -26,6 +27,24 @@ describe('processImageWithGPT4o', () => {
   test('returns raw string when JSON parse fails', async () => {
     axios.post.mockResolvedValue({ data: { choices: [{ message: { content: 'not json' } }] } });
     const result = await processImageWithGPT4o('img');
+    expect(result).toBe('not json');
+  });
+});
+
+describe('analyzeTableTextWithGPT4o', () => {
+  beforeEach(() => {
+    axios.post.mockReset();
+  });
+
+  test('parses JSON response', async () => {
+    axios.post.mockResolvedValue({ data: { choices: [{ message: { content: '{"a":1}' } }] } });
+    const result = await analyzeTableTextWithGPT4o('txt');
+    expect(result).toEqual({ a: 1 });
+  });
+
+  test('returns raw string when JSON parse fails', async () => {
+    axios.post.mockResolvedValue({ data: { choices: [{ message: { content: 'not json' } }] } });
+    const result = await analyzeTableTextWithGPT4o('txt');
     expect(result).toBe('not json');
   });
 });


### PR DESCRIPTION
## Summary
- allow OpenAI service to accept OCR text using new `analyzeTableTextWithGPT4o`
- test new function in `openaiService.test.js`
- document combined Tesseract + OpenAI workflow

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68629c50edc4832b86828f7498c41adf