### PR TITLE
Add logging

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -10,6 +10,7 @@ const bot = new TelegramBot(process.env.TELEGRAM_BOT_TOKEN, { polling: true });
 
 bot.on('message', async (msg) => {
   const chatId = msg.chat.id;
+  console.log('Mensaje recibido:', msg);
 
   if (msg.photo) {
     const fileId = msg.photo[msg.photo.length - 1].file_id;
@@ -17,11 +18,14 @@ bot.on('message', async (msg) => {
     const url = `https://api.telegram.org/file/bot${process.env.TELEGRAM_BOT_TOKEN}/${file.file_path}`;
 
     bot.sendMessage(chatId, '📥 Imagen recibida. Procesando...');
+    console.log('Descargando imagen desde Telegram:', url);
 
     try {
       const response = await axios.get(url, { responseType: 'arraybuffer' });
       const base64 = Buffer.from(response.data).toString('base64');
+      console.log('Tamaño de la imagen en base64:', base64.length);
       const result = await processImageWithGPT4o(base64);
+      console.log('Datos devueltos por OpenAI:', result);
 
       if (typeof result === 'object') {
         const buffer = await generateExcelFromData(result);

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 export async function processImageWithGPT4o(base64Image) {
+  console.log('Enviando imagen a OpenAI...');
   const response = await axios.post(
     'https://api.openai.com/v1/chat/completions',
     {
@@ -37,6 +38,7 @@ export async function processImageWithGPT4o(base64Image) {
   );
 
   const result = response.data.choices[0].message.content;
+  console.log('Respuesta de OpenAI:', result);
   try {
     return JSON.parse(result);
   } catch (err) {
@@ -45,6 +47,7 @@ export async function processImageWithGPT4o(base64Image) {
 }
 
 export async function analyzeTableTextWithGPT4o(ocrText) {
+  console.log('Enviando texto a OpenAI...', ocrText);
   const response = await axios.post(
     'https://api.openai.com/v1/chat/completions',
     {
@@ -70,6 +73,7 @@ export async function analyzeTableTextWithGPT4o(ocrText) {
   );
 
   const result = response.data.choices[0].message.content;
+  console.log('Respuesta de OpenAI:', result);
   try {
     return JSON.parse(result);
   } catch (err) {

--- a/src/services/tesseractService.js
+++ b/src/services/tesseractService.js
@@ -1,11 +1,13 @@
 import { createWorker } from 'tesseract.js';
 
 export async function processImageWithTesseract(imageBuffer, lang = 'eng') {
+  console.log('Procesando imagen con Tesseract...');
   const worker = await createWorker();
   try {
     await worker.loadLanguage(lang);
     await worker.initialize(lang);
     const { data: { text } } = await worker.recognize(imageBuffer);
+    console.log('Texto reconocido:', text);
     return text;
   } finally {
     await worker.terminate();


### PR DESCRIPTION
## Summary
- add console logging across the bot and services to show request flow

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68629d801c18832ba01aad7f6f720bf0