### PR TITLE
Use Tesseract OCR before GPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OCRbdb
 
-Este proyecto es un bot de Telegram que analiza imágenes de tablas, extrae su contenido utilizando OpenAI GPT-4o y entrega los datos resultantes ya sea en texto o en un archivo Excel.
+Este proyecto es un bot de Telegram que analiza imágenes de tablas. Primero extrae el texto de la imagen con Tesseract y luego utiliza OpenAI GPT-4o para estructurar los datos, ya sea en texto o en un archivo Excel.
 
 ## Requisitos previos
 
@@ -62,15 +62,9 @@ ISC
 
 ## Usar Tesseract como motor OCR
 
-Si prefieres que el reconocimiento de texto se realice de manera local,
-puedes utilizar [Tesseract.js](https://github.com/naptha/tesseract.js).
-Instálalo con:
-
-```bash
-npm install tesseract.js
-```
-
-Luego emplea el servicio `tesseractService.js` para extraer el texto:
+El bot emplea Tesseract de forma predeterminada para reconocer el texto de las imágenes.
+Si necesitas utilizar este servicio en otro contexto o modificar el idioma, puedes importar
+`processImageWithTesseract` desde `tesseractService.js`:
 
 ```javascript
 import { processImageWithTesseract } from './src/services/tesseractService.js';
@@ -80,10 +74,10 @@ const texto = await processImageWithTesseract(buffer, 'spa');
 const datos = await analyzeTableTextWithGPT4o(texto);
 ```
 
-Flujo sugerido:
+El flujo es el mismo que usa el bot:
 
-1. Recibir la imagen desde Telegram u otra fuente.
-2. Pasarla a `processImageWithTesseract` para obtener el texto plano.
-3. Enviar el texto a `analyzeTableTextWithGPT4o` para corregirlo y estructurarlo.
-4. Generar el Excel con `generateExcelFromData` usando los datos devueltos.
+1. Obtener la imagen.
+2. Ejecutar `processImageWithTesseract` para extraer el texto plano.
+3. Enviar ese texto a `analyzeTableTextWithGPT4o` para corregirlo y estructurarlo.
+4. Generar un Excel con `generateExcelFromData` si es necesario.
 

--- a/src/bot.js
+++ b/src/bot.js
@@ -3,8 +3,9 @@ dotenv.config();
 
 import TelegramBot from 'node-telegram-bot-api';
 import axios from 'axios';
-import { processImageWithGPT4o } from './services/openaiService.js';
+import { analyzeTableTextWithGPT4o } from './services/openaiService.js';
 import { generateExcelFromData } from './services/excelService.js';
+import { processImageWithTesseract } from './services/tesseractService.js';
 
 const bot = new TelegramBot(process.env.TELEGRAM_BOT_TOKEN, { polling: true });
 
@@ -22,9 +23,10 @@ bot.on('message', async (msg) => {
 
     try {
       const response = await axios.get(url, { responseType: 'arraybuffer' });
-      const base64 = Buffer.from(response.data).toString('base64');
-      console.log('Tamaño de la imagen en base64:', base64.length);
-      const result = await processImageWithGPT4o(base64);
+      const imageBuffer = Buffer.from(response.data);
+      console.log('Tamaño de la imagen (bytes):', imageBuffer.length);
+      const text = await processImageWithTesseract(imageBuffer, 'spa');
+      const result = await analyzeTableTextWithGPT4o(text);
       console.log('Datos devueltos por OpenAI:', result);
 
       if (typeof result === 'object') {


### PR DESCRIPTION
## Summary
- integrate `processImageWithTesseract` in bot flow
- send the OCR text to `analyzeTableTextWithGPT4o`
- adjust README to describe default Tesseract usage

## Testing
- `npm test` *(fails: Cannot find module '/workspace/OCRbdb/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68629ea27e08832b88c233c3adf683fd