### PR TITLE
Switch bot to PDF workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OCRbdb
 
-Este proyecto es un bot de Telegram que analiza imágenes de tablas. Primero extrae el texto de la imagen con Tesseract y luego utiliza OpenAI GPT-4o para estructurar los datos, ya sea en texto o en un archivo Excel.
+Este proyecto es un bot de Telegram que analiza tablas enviadas en formato PDF. Extrae el texto del PDF y luego utiliza OpenAI GPT-4o para estructurar los datos, ya sea en texto o en un archivo Excel.
 
 ## Requisitos previos
 
@@ -37,7 +37,7 @@ O con el script de npm:
 npm start
 ```
 
-Una vez en funcionamiento, envíale al bot una foto que contenga una tabla. El bot enviará un mensaje de confirmación mientras procesa la imagen.
+Una vez en funcionamiento, envíale al bot un archivo PDF que contenga la tabla. El bot enviará un mensaje de confirmación mientras procesa el documento.
 
 - Si los datos se reconocen como una colección de objetos, el bot generará un archivo `datos.xlsx` con la información estructurada.
 - En caso contrario, devolverá el texto extraído directamente en el chat.
@@ -47,7 +47,7 @@ Una vez en funcionamiento, envíale al bot una foto que contenga una tabla. El b
 - `src/bot.js`: punto de entrada del bot de Telegram.
 - `src/services/openaiService.js`: se comunica con la API de OpenAI para procesar la imagen o el texto extraído y obtener la información estructurada.
 - `src/services/excelService.js`: genera un archivo Excel a partir de los datos obtenidos.
-- `src/services/tesseractService.js`: extrae texto de imágenes utilizando Tesseract.
+- `src/services/pdfService.js`: extrae el texto de los archivos PDF recibidos.
 
 ## Variables de entorno
 
@@ -60,24 +60,22 @@ Una vez en funcionamiento, envíale al bot una foto que contenga una tabla. El b
 
 ISC
 
-## Usar Tesseract como motor OCR
+## Procesamiento de PDF
 
-El bot emplea Tesseract de forma predeterminada para reconocer el texto de las imágenes.
-Si necesitas utilizar este servicio en otro contexto o modificar el idioma, puedes importar
-`processImageWithTesseract` desde `tesseractService.js`:
+El bot emplea `pdf-parse` para extraer el texto de los documentos PDF recibidos. Posteriormente, envía ese texto a `analyzeTableTextWithGPT4o` para obtener los datos estructurados. Si necesitas usar este flujo de manera independiente:
 
 ```javascript
-import { processImageWithTesseract } from './src/services/tesseractService.js';
+import { extractTextFromPDF } from './src/services/pdfService.js';
 import { analyzeTableTextWithGPT4o } from './src/services/openaiService.js';
 
-const texto = await processImageWithTesseract(buffer, 'spa');
+const texto = await extractTextFromPDF(buffer);
 const datos = await analyzeTableTextWithGPT4o(texto);
 ```
 
-El flujo es el mismo que usa el bot:
+Los pasos del bot son los siguientes:
 
-1. Obtener la imagen.
-2. Ejecutar `processImageWithTesseract` para extraer el texto plano.
+1. Obtener el PDF.
+2. Extraer su texto con `extractTextFromPDF`.
 3. Enviar ese texto a `analyzeTableTextWithGPT4o` para corregirlo y estructurarlo.
 4. Generar un Excel con `generateExcelFromData` si es necesario.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "dotenv": "^17.0.0",
         "exceljs": "^4.4.0",
         "node-telegram-bot-api": "^0.66.0",
-        "tesseract.js": "^4.1.4"
+        "pdf-parse": "^1.1.1"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -6175,31 +6175,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/tesseract.js": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-4.1.4.tgz",
-      "integrity": "sha512-iLjJjLWVNV4PApofEsd54Y1MbjhzpPxEzF8EjYmC2CLN4hrUqO5aTNTSbGA7/QjycKtAWHhn2YmDR+6GFwi2Zg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bmp-js": "^0.1.0",
-        "idb-keyval": "^6.2.0",
-        "is-electron": "^2.2.2",
-        "is-url": "^1.2.4",
-        "node-fetch": "^2.6.9",
-        "opencollective-postinstall": "^2.0.3",
-        "regenerator-runtime": "^0.13.3",
-        "tesseract.js-core": "^4.0.4",
-        "wasm-feature-detect": "^1.2.11",
-        "zlibjs": "^0.3.1"
-      }
-    },
-    "node_modules/tesseract.js-core": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-4.0.4.tgz",
-      "integrity": "sha512-MJ+vtktjAaT0681uPl6TDUPhbRbpD/S9emko5rtorgHRZpQo7R3BG7h+3pVHgn1KjfNf1bvnx4B7KxEK8YKqpg==",
-      "license": "Apache License 2.0"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dotenv": "^17.0.0",
     "exceljs": "^4.4.0",
     "node-telegram-bot-api": "^0.66.0",
-    "tesseract.js": "^4.1.4"
+    "pdf-parse": "^1.1.1"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/src/services/pdfService.js
+++ b/src/services/pdfService.js
@@ -1,0 +1,6 @@
+import pdfParse from 'pdf-parse';
+
+export async function extractTextFromPDF(pdfBuffer) {
+  const data = await pdfParse(pdfBuffer);
+  return data.text;
+}

--- a/tests/pdfService.test.js
+++ b/tests/pdfService.test.js
@@ -1,0 +1,18 @@
+import { jest } from '@jest/globals';
+
+const parsed = { text: 'txt' };
+
+jest.unstable_mockModule('pdf-parse', () => ({
+  default: jest.fn().mockResolvedValue(parsed)
+}));
+
+let extractTextFromPDF;
+
+beforeAll(async () => {
+  ({ extractTextFromPDF } = await import('../src/services/pdfService.js'));
+});
+
+test('extractTextFromPDF returns parsed text', async () => {
+  const text = await extractTextFromPDF(Buffer.from('data'));
+  expect(text).toBe('txt');
+});


### PR DESCRIPTION
## Summary
- accept PDF documents instead of images
- drop tesseract flow
- add PDF text extraction service
- document new PDF workflow
- include unit test for pdf service

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6863c83e0084832b9a385094acf10fda