### PR TITLE
Add PDF helper in OpenAI service

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,20 +62,17 @@ ISC
 
 ## Procesamiento de PDF
 
-El bot emplea `pdf-parse` para extraer el texto de los documentos PDF recibidos. Posteriormente, envía ese texto a `analyzeTableTextWithGPT4o` para obtener los datos estructurados. Si necesitas usar este flujo de manera independiente:
+El bot emplea `pdf-parse` para extraer el texto de los documentos PDF recibidos. Luego puedes pasar ese texto a `analyzeTableTextWithGPT4o` o utilizar directamente `processPDFWithGPT4o`. Si necesitas usar este flujo de manera independiente:
 
 ```javascript
-import { extractTextFromPDF } from './src/services/pdfService.js';
-import { analyzeTableTextWithGPT4o } from './src/services/openaiService.js';
+import { processPDFWithGPT4o } from './src/services/openaiService.js';
 
-const texto = await extractTextFromPDF(buffer);
-const datos = await analyzeTableTextWithGPT4o(texto);
+const datos = await processPDFWithGPT4o(buffer);
 ```
 
 Los pasos del bot son los siguientes:
 
 1. Obtener el PDF.
-2. Extraer su texto con `extractTextFromPDF`.
-3. Enviar ese texto a `analyzeTableTextWithGPT4o` para corregirlo y estructurarlo.
-4. Generar un Excel con `generateExcelFromData` si es necesario.
+2. Extraer su texto con `extractTextFromPDF` y pasarlo a `analyzeTableTextWithGPT4o`, o usar `processPDFWithGPT4o` directamente.
+3. Generar un Excel con `generateExcelFromData` si es necesario.
 

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { extractTextFromPDF } from './pdfService.js';
 
 export async function processImageWithGPT4o(base64Image) {
   console.log('Enviando imagen a OpenAI...');
@@ -79,4 +80,9 @@ export async function analyzeTableTextWithGPT4o(ocrText) {
   } catch (err) {
     return result;
   }
+}
+
+export async function processPDFWithGPT4o(pdfBuffer) {
+  const text = await extractTextFromPDF(pdfBuffer);
+  return analyzeTableTextWithGPT4o(text);
 }

--- a/tests/openaiService.test.js
+++ b/tests/openaiService.test.js
@@ -4,13 +4,19 @@ jest.unstable_mockModule('axios', () => ({
   default: { post: jest.fn() }
 }));
 
+const extractMock = jest.fn();
+jest.unstable_mockModule('../src/services/pdfService.js', () => ({
+  extractTextFromPDF: extractMock
+}));
+
 let processImageWithGPT4o;
 let analyzeTableTextWithGPT4o;
+let processPDFWithGPT4o;
 let axios;
 
 beforeAll(async () => {
   ({ default: axios } = await import('axios'));
-  ({ processImageWithGPT4o, analyzeTableTextWithGPT4o } = await import('../src/services/openaiService.js'));
+  ({ processImageWithGPT4o, analyzeTableTextWithGPT4o, processPDFWithGPT4o } = await import('../src/services/openaiService.js'));
 });
 
 describe('processImageWithGPT4o', () => {
@@ -46,5 +52,21 @@ describe('analyzeTableTextWithGPT4o', () => {
     axios.post.mockResolvedValue({ data: { choices: [{ message: { content: 'not json' } }] } });
     const result = await analyzeTableTextWithGPT4o('txt');
     expect(result).toBe('not json');
+  });
+});
+
+describe('processPDFWithGPT4o', () => {
+  beforeEach(() => {
+    axios.post.mockReset();
+    extractMock.mockReset();
+  });
+
+  test('extracts text and parses JSON response', async () => {
+    extractMock.mockResolvedValue('pdf text');
+    axios.post.mockResolvedValue({ data: { choices: [{ message: { content: '{"a":1}' } }] } });
+    const buffer = Buffer.from('data');
+    const result = await processPDFWithGPT4o(buffer);
+    expect(extractMock).toHaveBeenCalledWith(buffer);
+    expect(result).toEqual({ a: 1 });
   });
 });


### PR DESCRIPTION
## Summary
- support processing PDF buffers in `openaiService`
- demonstrate the new function in the README
- mock pdf extraction in `openaiService` tests

## Testing
- `npm test` *(fails: cannot find module `jest`)*

------
https://chatgpt.com/codex/tasks/task_e_6863cb0f85e0832ba5d8797c1ba3bf71