### PR TITLE
Add direct image URL handling

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -3,15 +3,55 @@ dotenv.config();
 
 import TelegramBot from 'node-telegram-bot-api';
 import axios from 'axios';
-import { analyzeTableTextWithGPT4o } from './services/openaiService.js';
+import {
+  analyzeTableTextWithGPT4o,
+  processImageWithGPT4o,
+} from './services/openaiService.js';
 import { generateExcelFromData } from './services/excelService.js';
-import { extractTextFromPDF } from './services/pdfService.js';
+import { extractPagesFromPDF } from './services/pdfService.js';
 
 const bot = new TelegramBot(process.env.TELEGRAM_BOT_TOKEN, { polling: true });
 
 bot.on('message', async (msg) => {
   const chatId = msg.chat.id;
   console.log('Mensaje recibido:', msg);
+
+  if (msg.photo) {
+    const fileId = msg.photo[msg.photo.length - 1].file_id;
+    const file = await bot.getFile(fileId);
+    const url = `https://api.telegram.org/file/bot${process.env.TELEGRAM_BOT_TOKEN}/${file.file_path}`;
+
+    bot.sendMessage(chatId, '📥 Imagen recibida. Procesando...');
+    console.log('Descargando imagen desde Telegram:', url);
+
+    try {
+      // const response = await axios.get(url, { responseType: 'arraybuffer' });
+      // const imageBuffer = Buffer.from(response.data);
+      // const text = await processImageWithTesseract(imageBuffer, 'spa');
+      const result = await processImageWithGPT4o({ url });
+      console.log('Datos devueltos por OpenAI:', result);
+
+      if (typeof result === 'object') {
+        const buffer = await generateExcelFromData(result);
+        await bot.sendDocument(
+          chatId,
+          buffer,
+          {},
+          {
+            filename: 'datos.xlsx',
+            contentType:
+              'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          }
+        );
+      } else {
+        bot.sendMessage(chatId, `📋 Datos extraídos:\n\n${result}`);
+      }
+    } catch (error) {
+      console.error(error);
+      bot.sendMessage(chatId, '❌ Error al procesar la imagen.');
+    }
+    return;
+  }
 
   if (
     msg.document &&
@@ -29,24 +69,27 @@ bot.on('message', async (msg) => {
       const response = await axios.get(url, { responseType: 'arraybuffer' });
       const pdfBuffer = Buffer.from(response.data);
       console.log('Tamaño del PDF (bytes):', pdfBuffer.length);
-      const text = await extractTextFromPDF(pdfBuffer);
-      const result = await analyzeTableTextWithGPT4o(text);
-      console.log('Datos devueltos por OpenAI:', result);
+      const pages = await extractPagesFromPDF(pdfBuffer);
 
-      if (typeof result === 'object') {
-        const buffer = await generateExcelFromData(result);
-        await bot.sendDocument(
-          chatId,
-          buffer,
-          {},
-          {
-            filename: 'datos.xlsx',
-            contentType:
-              'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-          }
-        );
-      } else {
-        bot.sendMessage(chatId, `📋 Datos extraídos:\n\n${result}`);
+      for (const pageText of pages) {
+        const result = await analyzeTableTextWithGPT4o(pageText);
+        console.log('Datos devueltos por OpenAI:', result);
+
+        if (typeof result === 'object') {
+          const buffer = await generateExcelFromData(result);
+          await bot.sendDocument(
+            chatId,
+            buffer,
+            {},
+            {
+              filename: 'datos.xlsx',
+              contentType:
+                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            }
+          );
+        } else {
+          bot.sendMessage(chatId, `📋 Datos extraídos:\n\n${result}`);
+        }
       }
     } catch (error) {
       console.error(error);

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -1,8 +1,9 @@
 import axios from 'axios';
 import { extractTextFromPDF } from './pdfService.js';
 
-export async function processImageWithGPT4o(base64Image) {
+export async function processImageWithGPT4o({ url, base64 } = {}) {
   console.log('Enviando imagen a OpenAI...');
+  const imageUrl = url || `data:image/jpeg;base64,${base64}`;
   const response = await axios.post(
     'https://api.openai.com/v1/chat/completions',
     {
@@ -14,7 +15,7 @@ export async function processImageWithGPT4o(base64Image) {
             {
               type: 'image_url',
               image_url: {
-                url: `data:image/jpeg;base64,${base64Image}`,
+                url: imageUrl,
               },
             },
             {

--- a/src/services/pdfService.js
+++ b/src/services/pdfService.js
@@ -4,3 +4,11 @@ export async function extractTextFromPDF(pdfBuffer) {
   const data = await pdfParse(pdfBuffer);
   return data.text;
 }
+
+export async function extractPagesFromPDF(pdfBuffer) {
+  const text = await extractTextFromPDF(pdfBuffer);
+  return text
+    .split(/\f/g)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+}

--- a/tests/openaiService.test.js
+++ b/tests/openaiService.test.js
@@ -26,13 +26,13 @@ describe('processImageWithGPT4o', () => {
 
   test('parses JSON response', async () => {
     axios.post.mockResolvedValue({ data: { choices: [{ message: { content: '{"a":1}' } }] } });
-    const result = await processImageWithGPT4o('img');
+    const result = await processImageWithGPT4o({ url: 'img' });
     expect(result).toEqual({ a: 1 });
   });
 
   test('returns raw string when JSON parse fails', async () => {
     axios.post.mockResolvedValue({ data: { choices: [{ message: { content: 'not json' } }] } });
-    const result = await processImageWithGPT4o('img');
+    const result = await processImageWithGPT4o({ url: 'img' });
     expect(result).toBe('not json');
   });
 });

--- a/tests/pdfService.test.js
+++ b/tests/pdfService.test.js
@@ -7,12 +7,19 @@ jest.unstable_mockModule('pdf-parse', () => ({
 }));
 
 let extractTextFromPDF;
+let extractPagesFromPDF;
 
 beforeAll(async () => {
-  ({ extractTextFromPDF } = await import('../src/services/pdfService.js'));
+  ({ extractTextFromPDF, extractPagesFromPDF } = await import('../src/services/pdfService.js'));
 });
 
 test('extractTextFromPDF returns parsed text', async () => {
   const text = await extractTextFromPDF(Buffer.from('data'));
   expect(text).toBe('txt');
+});
+
+test('extractPagesFromPDF splits pages', async () => {
+  parsed.text = 'a\fb';
+  const pages = await extractPagesFromPDF(Buffer.from('data'));
+  expect(pages).toEqual(['a', 'b']);
 });


### PR DESCRIPTION
## Summary
- enable sending image URLs directly to OpenAI
- split PDF text into pages for per-page processing
- update Telegram bot to handle images and multipage PDFs
- comment out preprocessing step
- adjust tests for new utilities

## Testing
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_686d67beb028832babe6f254d9056d66